### PR TITLE
add_member: Print "unknown" warning only when group name is unknown

### DIFF
--- a/messenger.py
+++ b/messenger.py
@@ -34,16 +34,19 @@ def affichage_membre_groupe():
     accueil()
 
 def add_member():
-    group = input('Nom du groupe où ajouter:')
-    for d in server['users']:
-        print(d['name'], ":", d['id'])
+    matching_groups = []
+    while len(matching_groups) == 0:
+        group_name = input('Nom du groupe où ajouter:')
+        matching_groups = [group for group in server['channels'] if group['name'] == group_name]
+        if len(matching_groups) == 0:
+            print('Unknown group')
+    group = matching_groups[0]
+    for user in server['users']:
+        if user['id'] not in group['member_ids']:
+            print(user['name'], ":", user['id'])
     id_to_add = input('Quel id ajouter :')
-    for d in server['channels']:
-        if d['name']==group:
-            d['member_ids'].append(int(id_to_add))
-            print(d['member_ids'])
-    else :
-        print('Unkonw group')
+    group['member_ids'].append(int(id_to_add))
+    print(group['member_ids'])
     save_server()
     accueil()
 


### PR DESCRIPTION
Cette _pull request_ inclut 3 propositions de modifciation pour la fonction `add_member` :
1. L'alerte "Unknown group" n'est affichée que lorsque le nom du groupe est inconnu. Avec votre construction `for` / `else`, c'était possible en ajoutant une instruction `break` dans la clause `if`. Sans `break`, la clause `else` dur `for` est toujours exécutée.
2. L'alerte "Unknown group" est affichée avant de demander à l'utilisateur quel personne il souhaite rajouter dans le groupe, ce qui rend l'erreur plus claire. De manière générale, remonter une erreur dès qu'on peut en avoir connaissance est une bonne pratique.
3. Un filtre est ajouté pour n'afficher que les utilisateurs qui ne sont pas déjà membre du groupe.